### PR TITLE
Fix spammy debug message

### DIFF
--- a/src/vg/civcraft/mc/citadel/ReinforcementManager.java
+++ b/src/vg/civcraft/mc/citadel/ReinforcementManager.java
@@ -283,7 +283,9 @@ public class ReinforcementManager {
 						}
 					}
 					
-					saveManyReinforcements(reins);
+					if(reins.size() != 0){
+						saveManyReinforcements(reins);
+					}
 					
 					if (CitadelConfigManager.shouldLogInternal()) {
 						s = System.currentTimeMillis() - s;


### PR DESCRIPTION
This fixes the log getting spammed with `ReinforcementManager saveManyReinforcement called with null or empty` every time it saves (so every 100t).