### PR TITLE
Fixes issue where anyone could open reinforced chests/container/doors.

### DIFF
--- a/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -234,9 +234,12 @@ public class BlockListener implements Listener {
 		}
 	}
 	
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void preventStrippingLogs(PlayerInteractEvent pie) {
 		if (!pie.hasBlock()) {
+			return;
+		}
+		if (pie.getAction() != Action.RIGHT_CLICK_BLOCK) {
 			return;
 		}
 		Block block = pie.getClickedBlock();
@@ -268,9 +271,12 @@ public class BlockListener implements Listener {
 		}
 	}
 	
-	@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void preventTilingGrass(PlayerInteractEvent pie) {
 		if (!pie.hasBlock()) {
+			return;
+		}
+		if (pie.getAction() != Action.RIGHT_CLICK_BLOCK) {
 			return;
 		}
 		Block block = pie.getClickedBlock();

--- a/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -188,16 +188,18 @@ public class BlockListener implements Listener {
 		if (e.getClickedBlock().getState() instanceof Container) {
 			if (!rein.hasPermission(e.getPlayer(), CitadelPermissionHandler.getChests())) {
 				e.setUseInteractedBlock(Event.Result.DENY);
-				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED,
-						e.getClickedBlock().getType().name() + " is locked with " + rein.getType().getName());
+				String msg = String.format("%s is locked with %s%s", e.getClickedBlock().getType().name(),
+						ChatColor.AQUA, rein.getType().getName());
+				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, msg);
 			}
 			return;
 		}
 		if (e.getClickedBlock().getBlockData() instanceof Openable) {
 			if (!rein.hasPermission(e.getPlayer(), CitadelPermissionHandler.getDoors())) {
 				e.setUseInteractedBlock(Event.Result.DENY);
-				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED,
-						e.getClickedBlock().getType().name() + " is locked with " + rein.getType().getName());
+				String msg = String.format("%s is locked with %s%s", e.getClickedBlock().getType().name(),
+						ChatColor.AQUA, rein.getType().getName());
+				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, msg);
 			}
 		}
 	}

--- a/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -187,7 +187,7 @@ public class BlockListener implements Listener {
 		}
 		if (e.getClickedBlock().getState() instanceof Container) {
 			if (!rein.hasPermission(e.getPlayer(), CitadelPermissionHandler.getChests())) {
-				e.setUseInteractedBlock(Event.Result.DENY);
+				e.setCancelled(true);
 				String msg = String.format("%s is locked with %s%s", e.getClickedBlock().getType().name(),
 						ChatColor.AQUA, rein.getType().getName());
 				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, msg);
@@ -196,7 +196,7 @@ public class BlockListener implements Listener {
 		}
 		if (e.getClickedBlock().getBlockData() instanceof Openable) {
 			if (!rein.hasPermission(e.getPlayer(), CitadelPermissionHandler.getDoors())) {
-				e.setUseInteractedBlock(Event.Result.DENY);
+				e.setCancelled(true);
 				String msg = String.format("%s is locked with %s%s", e.getClickedBlock().getType().name(),
 						ChatColor.AQUA, rein.getType().getName());
 				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, msg);

--- a/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -8,6 +8,7 @@ import org.bukkit.block.Container;
 import org.bukkit.block.data.Openable;
 import org.bukkit.block.data.type.Comparator;
 import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -172,18 +173,21 @@ public class BlockListener implements Listener {
 	}
 
 	// prevent opening reinforced things
-	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void openContainer(PlayerInteractEvent e) {
 		if (!e.hasBlock()) {
+			return;
+		}
+		if (e.getAction() != Action.RIGHT_CLICK_BLOCK) {
 			return;
 		}
 		Reinforcement rein = ReinforcementLogic.getReinforcementProtecting(e.getClickedBlock());
 		if (rein == null) {
 			return;
 		}
-		if (e.getClickedBlock().getBlockData() instanceof Container) {
+		if (e.getClickedBlock().getState() instanceof Container) {
 			if (!rein.hasPermission(e.getPlayer(), CitadelPermissionHandler.getChests())) {
-				e.setCancelled(true);
+				e.setUseInteractedBlock(Event.Result.DENY);
 				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED,
 						e.getClickedBlock().getType().name() + " is locked with " + rein.getType().getName());
 			}
@@ -191,7 +195,7 @@ public class BlockListener implements Listener {
 		}
 		if (e.getClickedBlock().getBlockData() instanceof Openable) {
 			if (!rein.hasPermission(e.getPlayer(), CitadelPermissionHandler.getDoors())) {
-				e.setCancelled(true);
+				e.setUseInteractedBlock(Event.Result.DENY);
 				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED,
 						e.getClickedBlock().getType().name() + " is locked with " + rein.getType().getName());
 			}

--- a/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -173,7 +173,7 @@ public class BlockListener implements Listener {
 	}
 
 	// prevent opening reinforced things
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void openContainer(PlayerInteractEvent e) {
 		if (!e.hasBlock()) {
 			return;
@@ -234,7 +234,7 @@ public class BlockListener implements Listener {
 		}
 	}
 	
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void preventStrippingLogs(PlayerInteractEvent pie) {
 		if (!pie.hasBlock()) {
 			return;
@@ -271,7 +271,7 @@ public class BlockListener implements Listener {
 		}
 	}
 	
-	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void preventTilingGrass(PlayerInteractEvent pie) {
 		if (!pie.hasBlock()) {
 			return;


### PR DESCRIPTION
Fixes issue where anyone could open reinforced chests/container/doors.

- Changing the priority to HIGH is necessary, otherwise the player will open the inventory.

- The check for RIGHT_CLICK_BLOCK ensures that the event won't fire when a player tries to break the block or if using /cti. Removing this check would effectively prevent players from breaking the block.

- The e.setUseInteractedBlock(...) may be replaced by e.setCancelled(), in this case it does not seem to make any difference except that the bukkit documentation suggest that it's less restrictive as it doesn't cancel the event but only prevents the interaction with the block (ie: opening the GUI/door).