### PR TITLE
More Citadel protections

### DIFF
--- a/src/main/java/vg/civcraft/mc/citadel/CitadelPermissionHandler.java
+++ b/src/main/java/vg/civcraft/mc/citadel/CitadelPermissionHandler.java
@@ -48,7 +48,7 @@ public class CitadelPermissionHandler {
 				"Allows toggling the insecure flag on reinforcements");
 		modifyBlockPerm = PermissionType.registerPermission("MODIFY_BLOCK", new ArrayList<>(modAndAbove),
 				"Allows modifying reinforced blocks like flipping levers, strippling logs etc.");
-		beaconPerm = PermissionType.registerPermission("BEACON_EFFECT", new ArrayList<>(membersAndAbove),
+		beaconPerm = PermissionType.registerPermission("BEACONS", new ArrayList<>(membersAndAbove),
 				"Allow changing beacon effects");
 	}
 	

--- a/src/main/java/vg/civcraft/mc/citadel/CitadelPermissionHandler.java
+++ b/src/main/java/vg/civcraft/mc/citadel/CitadelPermissionHandler.java
@@ -22,6 +22,7 @@ public class CitadelPermissionHandler {
 	private static PermissionType infoPerm;
 	private static PermissionType repairPerm;
 	private static PermissionType modifyBlockPerm;
+	private static PermissionType beaconPerm;
 
 	public static void setup() {
 		List<PlayerType> membersAndAbove = Arrays.asList(PlayerType.MEMBERS, PlayerType.MODS, PlayerType.ADMINS,
@@ -47,6 +48,8 @@ public class CitadelPermissionHandler {
 				"Allows toggling the insecure flag on reinforcements");
 		modifyBlockPerm = PermissionType.registerPermission("MODIFY_BLOCK", new ArrayList<>(modAndAbove),
 				"Allows modifying reinforced blocks like flipping levers, strippling logs etc.");
+		beaconPerm = PermissionType.registerPermission("BEACON_EFFECT", new ArrayList<>(membersAndAbove),
+				"Allow changing beacon effects");
 	}
 	
 	public static PermissionType getModifyBlocks() {
@@ -87,6 +90,10 @@ public class CitadelPermissionHandler {
 
 	public static PermissionType getRepair() {
 		return repairPerm;
+	}
+
+	public static PermissionType getBeacon() {
+		return beaconPerm;
 	}
 
 }

--- a/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -346,4 +346,26 @@ public class BlockListener implements Listener {
 			pie.setCancelled(true);
 		}
 	}
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = false)
+	public void openBeacon(PlayerInteractEvent pie) {
+		if (!pie.hasBlock()) {
+			return;
+		}
+		if (pie.getAction() != Action.RIGHT_CLICK_BLOCK) {
+			return;
+		}
+		Reinforcement rein = ReinforcementLogic.getReinforcementProtecting(pie.getClickedBlock());
+		if (rein == null) {
+			return;
+		}
+		if (pie.getClickedBlock().getType() == Material.BEACON) {
+			if (!rein.hasPermission(pie.getPlayer(), CitadelPermissionHandler.getBeacon())) {
+				pie.setCancelled(true);
+				String msg = String.format("%s is locked with %s%s", pie.getClickedBlock().getType().name(),
+						ChatColor.AQUA, rein.getType().getName());
+				CitadelUtility.sendAndLog(pie.getPlayer(), ChatColor.RED, msg);
+			}
+		}
+	}
 }

--- a/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -307,4 +307,43 @@ public class BlockListener implements Listener {
 			pie.setCancelled(true);
 		}
 	}
+
+	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+	public void preventTillingDirtIntoFarmland(PlayerInteractEvent pie) {
+		if (!pie.hasBlock()) {
+			return;
+		}
+		if (pie.getAction() != Action.RIGHT_CLICK_BLOCK) {
+			return;
+		}
+		Block block = pie.getClickedBlock();
+		Material type = block.getType();
+		if (type != Material.GRASS_BLOCK && type != Material.DIRT && type != Material.COARSE_DIRT
+				&& type != Material.GRASS_PATH) {
+			return;
+		}
+		EquipmentSlot hand = pie.getHand();
+		if (hand != EquipmentSlot.HAND && hand != EquipmentSlot.OFF_HAND) {
+			return;
+		}
+		ItemStack relevant;
+		Player p = pie.getPlayer();
+		if (hand == EquipmentSlot.HAND) {
+			relevant = p.getInventory().getItemInMainHand();
+		}
+		else {
+			relevant = p.getInventory().getItemInOffHand();
+		}
+		if (!ToolAPI.isHoe(relevant.getType())) {
+			return;
+		}
+		Reinforcement rein = Citadel.getInstance().getReinforcementManager().getReinforcement(block);
+		if (rein == null) {
+			return;
+		}
+		if (!rein.hasPermission(p, CitadelPermissionHandler.getModifyBlocks())) {
+			p.sendMessage(ChatColor.RED + "You do not have permission to modify this block");
+			pie.setCancelled(true);
+		}
+	}
 }


### PR DESCRIPTION
- Prevent players that do not have `/ctb` access from turning grass/dirt/path into farmland and coarse dirt into normal dirt.
- Prevents players that do not have the new `BEACONS` permission from opening beacons and changing the effect. From what I understand from https://wiki.vg/Protocol#Set_Beacon_Effect, the protocol does not specify a way to change the beacon effect outside the beacon window for non-privileged users. This means that it cannot be bypassed by a custom client.