### PR TITLE
fixes #25 and #35 and double reinforcement

### DIFF
--- a/src/main/java/vg/civcraft/mc/citadel/listener/InventoryListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/InventoryListener.java
@@ -1,50 +1,90 @@
 package vg.civcraft.mc.citadel.listener;
 
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.Container;
+import org.bukkit.block.Dispenser;
+import org.bukkit.block.DoubleChest;
+import org.bukkit.block.Dropper;
+import org.bukkit.block.Hopper;
+import org.bukkit.block.data.Directional;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryMoveItemEvent;
 import org.bukkit.inventory.Inventory;
-
+import org.bukkit.inventory.InventoryHolder;
 import vg.civcraft.mc.citadel.ReinforcementLogic;
 import vg.civcraft.mc.citadel.model.Reinforcement;
+import vg.civcraft.mc.civmodcore.api.BlockAPI;
+import vg.civcraft.mc.civmodcore.util.Iteration;
 
 public class InventoryListener implements Listener {
 
-	// prevent sucking reinforcements out of reinforced containers with hoppers on
-	// different groups or filling into them
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void onInventoryMoveItemEvent(InventoryMoveItemEvent event) {
-		Inventory sourceInv = event.getSource();
-		Reinforcement sourceRein = null;
-		if (sourceInv.getHolder() instanceof Container) {
-			sourceRein = ReinforcementLogic.getReinforcementProtecting(((Container) sourceInv.getHolder()).getBlock());
+		Inventory fromInventory = event.getSource();
+		Inventory destInventory = event.getDestination();
+		InventoryHolder fromHolder = fromInventory.getHolder();
+		InventoryHolder destHolder = destInventory.getHolder();
+		// Determine the reinforcement of the source
+		Reinforcement fromReinforcement = null;
+		if (fromHolder instanceof Container) {
+			Container container = (Container) fromHolder;
+			fromReinforcement = ReinforcementLogic.getReinforcementProtecting(container.getBlock());
 		}
-		Inventory destInv = event.getDestination();
-		Reinforcement destRein = null;
-		if (destInv.getHolder() instanceof Container) {
-			destRein = ReinforcementLogic.getReinforcementProtecting(((Container) destInv.getHolder()).getBlock());
+		else if (fromHolder instanceof DoubleChest) {
+			DoubleChest doubleChest = (DoubleChest) fromHolder;
+			Block doubleChestBlock = doubleChest.getLocation().getBlock();
+			Location chestLocation = doubleChestBlock.getLocation(); // Yes this is necessary
+			Location otherLocation = BlockAPI.getOtherDoubleChestBlock(doubleChestBlock).getLocation();
+			if (destHolder instanceof Hopper) {
+				Location drainedLocation = ((Hopper) destHolder).getLocation().add(0, 1, 0);
+				if (Iteration.contains(drainedLocation, chestLocation, otherLocation)) {
+					fromReinforcement = ReinforcementLogic.getReinforcementProtecting(drainedLocation.getBlock());
+				}
+			}
 		}
-		if (sourceRein == null && destRein == null) {
+		// Determine the reinforcement of the destination
+		Reinforcement destReinforcement = null;
+		if (fromHolder instanceof Hopper || fromHolder instanceof Dropper || fromHolder instanceof Dispenser) {
+			Container container = (Container) fromHolder;
+			BlockFace direction = ((Directional) container.getBlockData()).getFacing();
+			destReinforcement = ReinforcementLogic.getReinforcementProtecting(
+					container.getBlock().getRelative(direction));
+		}
+		else if (destHolder instanceof Container) {
+			Container container = (Container) destHolder;
+			destReinforcement = ReinforcementLogic.getReinforcementProtecting(container.getBlock());
+		}
+		// Allow the transfer if neither are reinforced
+		if (fromReinforcement == null && destReinforcement == null) {
 			return;
 		}
-		if (sourceRein != null && destRein == null) {
-			if (!sourceRein.isInsecure()) {
+		// Allow the transfer if the destination is un-reinforced and the source is insecure
+		if (destReinforcement == null) {
+			if (!fromReinforcement.isInsecure()) {
 				event.setCancelled(true);
 			}
 			return;
 		}
-		//destRein is for sure not null at this point
-		if (sourceRein == null) {
-			if (!destRein.isInsecure()) {
+		// Allow the transfer if the source is un-reinforced and the destination is insecure
+		if (fromReinforcement == null) {
+			if (!destReinforcement.isInsecure()) {
 				event.setCancelled(true);
 			}
 			return;
 		}
-		// both reinforced at this point
-		if (sourceRein.getGroup().getGroupId() != destRein.getGroup().getGroupId()) {
-			event.setCancelled(true);
+		// Allow the transfer if both the source and destination are insecure
+		if (fromReinforcement.isInsecure() && destReinforcement.isInsecure()) {
+			return;
 		}
+		// Allow the transfer if both the source and destination are on the same group
+		if (fromReinforcement.getGroupId() == destReinforcement.getGroupId()) {
+			return;
+		}
+		event.setCancelled(true);
 	}
+
 }

--- a/src/main/java/vg/civcraft/mc/citadel/listener/InventoryListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/InventoryListener.java
@@ -37,7 +37,7 @@ public class InventoryListener implements Listener {
 		else if (fromHolder instanceof DoubleChest) {
 			DoubleChest doubleChest = (DoubleChest) fromHolder;
 			Block doubleChestBlock = doubleChest.getLocation().getBlock();
-			Location chestLocation = doubleChestBlock.getLocation(); // Yes this is necessary
+			Location chestLocation = doubleChestBlock.getLocation(); // Yes this is necessary otherwise .5 values
 			Location otherLocation = BlockAPI.getOtherDoubleChestBlock(doubleChestBlock).getLocation();
 			if (destHolder instanceof Hopper) {
 				Location drainedLocation = ((Hopper) destHolder).getLocation().add(0, 1, 0);

--- a/src/main/java/vg/civcraft/mc/citadel/playerstate/FortificationState.java
+++ b/src/main/java/vg/civcraft/mc/citadel/playerstate/FortificationState.java
@@ -1,22 +1,23 @@
 package vg.civcraft.mc.citadel.playerstate;
 
 import org.bukkit.ChatColor;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
-
 import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.CitadelUtility;
+import vg.civcraft.mc.citadel.ReinforcementLogic;
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
 import vg.civcraft.mc.namelayer.group.Group;
 
 public class FortificationState extends AbstractPlayerState {
 
-	private ReinforcementType type;
-	private Group group;
+	private final ReinforcementType type;
+	private final Group group;
 
-	public FortificationState(Player p, ReinforcementType type, Group group) {
-		super(p);
+	public FortificationState(Player player, ReinforcementType type, Group group) {
+		super(player);
 		this.type = type;
 		this.group = group;
 	}
@@ -36,24 +37,29 @@ public class FortificationState extends AbstractPlayerState {
 	}
 
 	@Override
-	public void handleBlockPlace(BlockPlaceEvent e) {
-		boolean hadError = CitadelUtility.attemptReinforcementCreation(e.getBlock(), type, group, e.getPlayer());
-		if (hadError) {
-			e.setCancelled(true);
-			Citadel.getInstance().getStateManager().setState(e.getPlayer(), null);
+	public void handleBlockPlace(BlockPlaceEvent event) {
+		Player player = event.getPlayer();
+		Block block = event.getBlock();
+		// Prevent double reinforcement (double chests / slabs)
+		if (ReinforcementLogic.getReinforcementProtecting(block) != null) {
+			return;
+		}
+		if (CitadelUtility.attemptReinforcementCreation(block, type, group, player)) { // true == fail
+			Citadel.getInstance().getStateManager().setState(player, null);
+			event.setCancelled(true);
+			//return;
 		}
 	}
 
 	@Override
-	public void handleInteractBlock(PlayerInteractEvent e) {
-	}
+	public void handleInteractBlock(PlayerInteractEvent event) { }
 
 	@Override
-	public boolean equals(Object o) {
-		if (!(o instanceof FortificationState)) {
+	public boolean equals(Object other) {
+		if (!(other instanceof FortificationState)) {
 			return false;
 		}
-		FortificationState fort = (FortificationState) o;
+		FortificationState fort = (FortificationState) other;
 		return fort.type == this.type && fort.group.getName().equals(this.getGroup().getName());
 	}
 

--- a/src/main/java/vg/civcraft/mc/citadel/playerstate/FortificationState.java
+++ b/src/main/java/vg/civcraft/mc/citadel/playerstate/FortificationState.java
@@ -40,8 +40,8 @@ public class FortificationState extends AbstractPlayerState {
 	public void handleBlockPlace(BlockPlaceEvent event) {
 		Player player = event.getPlayer();
 		Block block = event.getBlock();
-		// Prevent double reinforcement (double chests / slabs)
-		if (ReinforcementLogic.getReinforcementProtecting(block) != null) {
+		// Prevent double reinforcement (slabs)
+		if (ReinforcementLogic.getReinforcementAt(block.getLocation()) != null) {
 			return;
 		}
 		if (CitadelUtility.attemptReinforcementCreation(block, type, group, player)) { // true == fail


### PR DESCRIPTION
The big set of changes in the switch is *mostly* just fixing the indentation and Github is displaying it weirdly. The substantive changes are as follows:

1. Bed data is read from block data instead of the deprecated material data. This *appears* to have fixed the issue on my test server.

2. The double chest reinforcement check has been embedded into `getReinforcementProtecting()`

3. There's a reinforcement check when placing blocks in Fortification mode to prevent double reinforcement, such as with double chests and slabs.