### PR TITLE
Potential Chunk lag fix

### DIFF
--- a/src/main/java/vg/civcraft/mc/citadel/ReinforcementLogic.java
+++ b/src/main/java/vg/civcraft/mc/citadel/ReinforcementLogic.java
@@ -96,10 +96,15 @@ public final class ReinforcementLogic {
 			case CHEST:
 			case TRAPPED_CHEST: {
 				Chest chest = (Chest) block.getBlockData();
+				BlockFace facing = chest.getFacing();
 				switch (chest.getType()) {
-					case LEFT:
+					case LEFT: {
+						BlockFace face = BlockAPI.turnClockwise(facing);
+						return getReinforcementAt(block.getLocation().add(face.getDirection()));
+					}
 					case RIGHT: {
-						return getReinforcementAt(BlockAPI.getOtherDoubleChestBlock(block).getLocation());
+						BlockFace face = BlockAPI.turnAntiClockwise(facing);
+						return getReinforcementAt(block.getLocation().add(face.getDirection()));
 					}
 					default: {
 						return null;

--- a/src/main/java/vg/civcraft/mc/citadel/listener/InventoryListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/InventoryListener.java
@@ -1,8 +1,9 @@
 package vg.civcraft.mc.citadel.listener;
 
+import java.util.Objects;
 import org.bukkit.Location;
-import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.Chest;
 import org.bukkit.block.Container;
 import org.bukkit.block.Dispenser;
 import org.bukkit.block.DoubleChest;
@@ -17,7 +18,6 @@ import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.InventoryHolder;
 import vg.civcraft.mc.citadel.ReinforcementLogic;
 import vg.civcraft.mc.citadel.model.Reinforcement;
-import vg.civcraft.mc.civmodcore.api.BlockAPI;
 import vg.civcraft.mc.civmodcore.util.Iteration;
 
 public class InventoryListener implements Listener {
@@ -36,9 +36,8 @@ public class InventoryListener implements Listener {
 		}
 		else if (fromHolder instanceof DoubleChest) {
 			DoubleChest doubleChest = (DoubleChest) fromHolder;
-			Block doubleChestBlock = doubleChest.getLocation().getBlock();
-			Location chestLocation = doubleChestBlock.getLocation(); // Yes this is necessary otherwise .5 values
-			Location otherLocation = BlockAPI.getOtherDoubleChestBlock(doubleChestBlock).getLocation();
+			Location chestLocation = Objects.requireNonNull((Chest) doubleChest.getLeftSide()).getLocation();
+			Location otherLocation = Objects.requireNonNull((Chest) doubleChest.getRightSide()).getLocation();
 			if (destHolder instanceof Hopper) {
 				Location drainedLocation = ((Hopper) destHolder).getLocation().add(0, 1, 0);
 				if (Iteration.contains(drainedLocation, chestLocation, otherLocation)) {


### PR DESCRIPTION
Here's a potential fix to the chunk loading issue caused by Hoppers from the last PR (#36)

I have done some testing and it appears to have the same functionality as before except now there's no chunk loading involved, or at least `InventoryMoveItemEvent` isn't appearing on my timings *at all* despite deliberately setting up a hopper draining a double chest that's split between a loaded and unloaded chunk.