### PR TITLE
Stop the ReinforcementManager from exposing already invalid reinforcements.

### DIFF
--- a/src/main/java/vg/civcraft/mc/citadel/ReinforcementManager.java
+++ b/src/main/java/vg/civcraft/mc/citadel/ReinforcementManager.java
@@ -2,36 +2,49 @@ package vg.civcraft.mc.citadel;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
-
 import vg.civcraft.mc.citadel.model.CitadelChunkData;
 import vg.civcraft.mc.citadel.model.Reinforcement;
 import vg.civcraft.mc.civmodcore.locations.chunkmeta.api.BlockBasedChunkMetaView;
 import vg.civcraft.mc.civmodcore.locations.chunkmeta.block.table.TableBasedDataObject;
 import vg.civcraft.mc.civmodcore.locations.chunkmeta.block.table.TableStorageEngine;
 
+import java.util.Optional;
+
 public class ReinforcementManager {
 
 	private BlockBasedChunkMetaView<CitadelChunkData, TableBasedDataObject, TableStorageEngine<Reinforcement>> chunkMetaData;
 
-	ReinforcementManager(
-			BlockBasedChunkMetaView<CitadelChunkData, TableBasedDataObject, TableStorageEngine<Reinforcement>> chunkMetaData) {
+	ReinforcementManager(BlockBasedChunkMetaView<CitadelChunkData, TableBasedDataObject, TableStorageEngine<Reinforcement>> chunkMetaData) {
 		this.chunkMetaData = chunkMetaData;
 	}
 
 	/**
 	 * Gets the reinforcement at the given location if one exists
-	 * 
+	 *
 	 * @param location Location to get reinforcement for
 	 * @return Reinforcement at the location or null if no reinforcement exists
-	 *         there
+	 * there
 	 */
 	public Reinforcement getReinforcement(Location location) {
-		return (Reinforcement) chunkMetaData.get(location);
+		return Optional.ofNullable((Reinforcement) chunkMetaData.get(location))
+				.filter(this::isValidReinforcement)
+				.orElse(null);
+	}
+
+	private boolean isValidReinforcement(Reinforcement reinforcement) {
+		if (reinforcement == null) {
+			return false;
+		} else if (reinforcement.isBroken()) {
+			Citadel.getInstance().getLogger().warning("Trying to return a broken reinforcement from the backend. @" + reinforcement.getLocation());
+			return false;
+		} else {
+			return true;
+		}
 	}
 
 	/**
 	 * Gets the reinforcement for the given block if one exists
-	 * 
+	 *
 	 * @param block Block to get reinforcement for
 	 * @return Reinforcement for the block or null if no reinforcement exists there
 	 */
@@ -42,7 +55,7 @@ public class ReinforcementManager {
 	/**
 	 * Inserts the given reinforcement into the tracking. If a reinforcement already
 	 * exists at the same location it will be replaced.
-	 * 
+	 *
 	 * @param reinforcement Reinforcement to insert
 	 */
 	public void putReinforcement(Reinforcement reinforcement) {

--- a/src/main/java/vg/civcraft/mc/citadel/model/HologramManager.java
+++ b/src/main/java/vg/civcraft/mc/citadel/model/HologramManager.java
@@ -55,6 +55,11 @@ public class HologramManager {
 			holo = new PlayerHolo(player, rein);
 			locationSpecificHolos.put(player.getUniqueId(), holo);
 		}
+
+		if(holo.reinforcement.getHealth() <= 0.0) {
+			holo.reinforcement = rein;
+		}
+
 		activeHolos.add(holo);
 		holo.show();
 	}


### PR DESCRIPTION
Stop the ReinforcementManager from exposing already invalid reinforcements to the outside world. The manager will now map broken reinforcements to null instead. This should fix the issue of unbreakable bastions that go into negative health.

Another small fix in this pull request updates holograms if they are on a broken and then replaced reinforced block.