### PR TITLE
Configurable CTI hologram size

### DIFF
--- a/src/main/java/vg/civcraft/mc/citadel/listener/ModeListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/ModeListener.java
@@ -7,6 +7,9 @@ import java.util.concurrent.TimeUnit;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -15,6 +18,7 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.util.RayTraceResult;
 
 import vg.civcraft.mc.citadel.Citadel;
 import vg.civcraft.mc.citadel.CitadelPermissionHandler;
@@ -30,6 +34,7 @@ import vg.civcraft.mc.citadel.playerstate.PlayerStateManager;
 import vg.civcraft.mc.civmodcore.playersettings.PlayerSetting;
 import vg.civcraft.mc.civmodcore.playersettings.SettingChangeListener;
 import vg.civcraft.mc.civmodcore.playersettings.impl.DisplayLocationSetting;
+import vg.civcraft.mc.civmodcore.ratelimiting.RateLimiter;
 import vg.civcraft.mc.civmodcore.scoreboard.bottom.BottomLine;
 import vg.civcraft.mc.civmodcore.scoreboard.bottom.BottomLineAPI;
 import vg.civcraft.mc.civmodcore.scoreboard.side.CivScoreBoard;
@@ -200,60 +205,89 @@ public class ModeListener implements Listener {
 		if (!settingMan.getInformationMode().getValue(e.getPlayer())) {
 			return;
 		}
-		Reinforcement rein = ReinforcementLogic.getReinforcementProtecting(e.getClickedBlock());
 		Player player = e.getPlayer();
-		boolean showChat = settingMan.shouldShowChatInCti(player.getUniqueId());
-		if (rein == null) {
-			if (showChat) {
-				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.YELLOW, "Not reinforced");
-			}
-			return;
-		}
-		if (player.getGameMode() == GameMode.CREATIVE && e.getAction() == Action.LEFT_CLICK_BLOCK) {
-			e.setCancelled(true);
-		}
+		Location playerLoc = player.getEyeLocation();
+
+		RateLimiter raytrace_rateLimiter = settingMan.getRateLimiter();
+		boolean isRateLimited = !raytrace_rateLimiter.pullToken(player);
 		boolean showHolo = settingMan.shouldShowHologramInCti(player.getUniqueId());
-		if (!rein.hasPermission(player, CitadelPermissionHandler.getInfo())) {
-			if (showChat) {
-				Citadel.getInstance().getSettingManager().sendCtiEnemyMessage(player, rein);
-			}
-			if (showHolo) {
-				showHolo(rein, player);
-			}
-			return;
-		}
-		if (showChat) {
-			StringBuilder sb = new StringBuilder();
-			sb.append(String.format("Reinforced at %s%s health with %s%s %son %s%s ", formatHealth(rein),
-					ChatColor.GREEN, ChatColor.AQUA, rein.getType().getName(), ChatColor.GREEN, ChatColor.LIGHT_PURPLE,
-					rein.getGroup().getName()));
-			if (!rein.isMature()) {
-				sb.append(ChatColor.GOLD);
-				sb.append(formatProgress(rein.getCreationTime(), rein.getType().getMaturationTime(), "mature"));
-				sb.append(" ");
-			}
-			if (rein.isInsecure()) {
-				sb.append(ChatColor.AQUA);
-				sb.append("(Insecure) ");
-			}
-			if (ReinforcementLogic.getDecayDamage(rein) != 1) {
-				String ctiDecayAmountFormat = commaFormat.format(ReinforcementLogic.getDecayDamage(rein));
-				sb.append(String.format("%s(Decayed x%s) ", ChatColor.LIGHT_PURPLE, ctiDecayAmountFormat));
-			}
-			AcidManager acidMan = Citadel.getInstance().getAcidManager();
-			if (acidMan.isPossibleAcidBlock(e.getClickedBlock())) {
-				sb.append(ChatColor.GOLD);
-				long remainingTime = acidMan.getRemainingAcidMaturationTime(rein);
-				if (remainingTime == 0) {
-					sb.append("Acid ready");
-				} else {
-					sb.append(String.format("%sAcid block mature in %s", ChatColor.YELLOW, TextUtil.formatDuration(remainingTime, TimeUnit.MILLISECONDS)));
+		int xdist = settingMan.ctiXdist(player.getUniqueId());
+		int ydist = settingMan.ctiYdist(player.getUniqueId());
+		int zdist = settingMan.ctiZdist(player.getUniqueId());
+
+		for (int x = -xdist; x <=xdist; x++) {
+			for (int y = -ydist; y <=ydist; y++) {
+				for (int z = -zdist; z <=zdist; z++) {
+					final Block block = e.getClickedBlock().getRelative(x,y,z);
+					if (x == 0 && y == 0 && z == 0) {
+						final Reinforcement rein = ReinforcementLogic.getReinforcementProtecting(block);
+						boolean showChat = settingMan.shouldShowChatInCti(player.getUniqueId());
+						if (rein == null) {
+							if (showChat) {
+								CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.YELLOW, "Not reinforced");
+							}
+							continue;
+						}
+						if (player.getGameMode() == GameMode.CREATIVE && e.getAction() == Action.LEFT_CLICK_BLOCK) {
+							e.setCancelled(true);
+						}
+						if (!rein.hasPermission(player, CitadelPermissionHandler.getInfo())) {
+							if (showChat) {
+								Citadel.getInstance().getSettingManager().sendCtiEnemyMessage(player, rein);
+							}
+							if (showHolo) {
+								showHolo(rein, player);
+							}
+							continue;
+						}
+						if (showChat) {
+							StringBuilder sb = new StringBuilder();
+							sb.append(String.format("Reinforced at %s%s health with %s%s %son %s%s ", formatHealth(rein),
+									ChatColor.GREEN, ChatColor.AQUA, rein.getType().getName(), ChatColor.GREEN, ChatColor.LIGHT_PURPLE,
+									rein.getGroup().getName()));
+							if (!rein.isMature()) {
+								sb.append(ChatColor.GOLD);
+								sb.append(formatProgress(rein.getCreationTime(), rein.getType().getMaturationTime(), "mature"));
+								sb.append(" ");
+							}
+							if (rein.isInsecure()) {
+								sb.append(ChatColor.AQUA);
+								sb.append("(Insecure) ");
+							}
+							if (ReinforcementLogic.getDecayDamage(rein) != 1) {
+								String ctiDecayAmountFormat = commaFormat.format(ReinforcementLogic.getDecayDamage(rein));
+								sb.append(String.format("%s(Decayed x%s) ", ChatColor.LIGHT_PURPLE, ctiDecayAmountFormat));
+							}
+							AcidManager acidMan = Citadel.getInstance().getAcidManager();
+							if (acidMan.isPossibleAcidBlock(block)) {
+								sb.append(ChatColor.GOLD);
+								long remainingTime = acidMan.getRemainingAcidMaturationTime(rein);
+								if (remainingTime == 0) {
+									sb.append("Acid ready");
+								} else {
+									sb.append(String.format("%sAcid block mature in %s", ChatColor.YELLOW, TextUtil.formatDuration(remainingTime, TimeUnit.MILLISECONDS)));
+								}
+							}
+							CitadelUtility.sendAndLog(player, ChatColor.GREEN, sb.toString().trim());
+						}
+						if (showHolo) {
+							showHolo(rein, player);
+						}
+					} else if (showHolo && !isRateLimited && block.isSolid()) {
+						Vector blockLoc = block.getLocation().toVector().add(new Vector(0.5, 0.5, 0.5));
+						Vector direction = blockLoc.clone().subtract(playerLoc.toVector());
+						direction.normalize();
+
+						RayTraceResult ray = player.getWorld().rayTraceBlocks(playerLoc, direction, blockLoc.distance(playerLoc.toVector()));
+						if (ray != null && ray.getHitBlock() != null && ray.getHitBlock().equals(block)) {
+							Reinforcement rein = ReinforcementLogic.getReinforcementProtecting(block);
+							if (rein != null) {
+								showHolo(rein, player);
+							}
+						}
+					}
 				}
 			}
-			CitadelUtility.sendAndLog(player, ChatColor.GREEN, sb.toString().trim());
-		}
-		if (showHolo) {
-			showHolo(rein, player);
 		}
 	}
 

--- a/src/main/java/vg/civcraft/mc/citadel/model/CitadelSettingManager.java
+++ b/src/main/java/vg/civcraft/mc/citadel/model/CitadelSettingManager.java
@@ -15,6 +15,8 @@ import vg.civcraft.mc.citadel.CitadelUtility;
 import vg.civcraft.mc.citadel.ReinforcementLogic;
 import vg.civcraft.mc.citadel.listener.ModeListener;
 import vg.civcraft.mc.citadel.reinforcementtypes.ReinforcementType;
+import vg.civcraft.mc.civmodcore.ratelimiting.RateLimiter;
+import vg.civcraft.mc.civmodcore.ratelimiting.RateLimiting;
 import vg.civcraft.mc.civmodcore.playersettings.PlayerSettingAPI;
 import vg.civcraft.mc.civmodcore.playersettings.gui.MenuSection;
 import vg.civcraft.mc.civmodcore.playersettings.impl.BooleanSetting;
@@ -36,6 +38,11 @@ public class CitadelSettingManager {
 	private BooleanSetting ctoDisableCtb;
 
 	private BoundedIntegerSetting hologramDuration;
+	private BoundedIntegerSetting ctiXdist;
+	private BoundedIntegerSetting ctiYdist;
+	private BoundedIntegerSetting ctiZdist;
+
+	private RateLimiter rateLimiter;
 
 	private CommandReplySetting ctiNotReinforced;
 	// private CommandReplySetting ctiAllied;
@@ -97,9 +104,17 @@ public class CitadelSettingManager {
 		return easyMode.getValue(uuid);
 	}
 
+	public int ctiXdist(UUID uuid) { return ctiXdist.getValue(uuid); }
+
+	public int ctiYdist(UUID uuid) { return ctiYdist.getValue(uuid); }
+
+	public int ctiZdist(UUID uuid) { return ctiZdist.getValue(uuid); }
+
 	public int getHologramDuration(UUID uuid) {
 		return hologramDuration.getValue(uuid);
 	}
+
+	public RateLimiter getRateLimiter() { return rateLimiter; }
 
 	void initSettings() {
 		MenuSection menu = PlayerSettingAPI.getMainMenu().createMenuSection("Citadel",
@@ -129,6 +144,24 @@ public class CitadelSettingManager {
 				"How long should holograms in information mode remain visible, measured in milli seconds", false, 1000,
 				30000);
 		PlayerSettingAPI.registerSetting(hologramDuration, menu);
+
+		ctiXdist = new BoundedIntegerSetting(Citadel.getInstance(), 0, "cti X distance",
+				"citadelCtiXdist", new ItemStack(Material.RED_BANNER),
+				"How far out from block clicked should cti holograms extend", false, 0,
+				2);
+		PlayerSettingAPI.registerSetting(ctiXdist, menu);
+
+		ctiYdist = new BoundedIntegerSetting(Citadel.getInstance(), 0, "cti Y distance",
+				"citadelCtiYdist", new ItemStack(Material.GREEN_BANNER),
+				"How far out from block clicked should cti holograms extend", false, 0,
+				2);
+		PlayerSettingAPI.registerSetting(ctiYdist, menu);
+
+		ctiZdist = new BoundedIntegerSetting(Citadel.getInstance(), 0, "cti Z distance",
+				"citadelCtiZdist", new ItemStack(Material.BLUE_BANNER),
+				"How far out from block clicked should cti holograms extend", false, 0,
+				2);
+		PlayerSettingAPI.registerSetting(ctiZdist, menu);
 		
 		ctbLocationSetting = new DisplayLocationSetting(Citadel.getInstance(), DisplayLocation.NONE, "Bypass display location"
 				, "citadelBypassDisplayLocation", new ItemStack(Material.GOLDEN_PICKAXE), "bypass");
@@ -193,6 +226,8 @@ public class CitadelSettingManager {
 				"a color representing the reinforcement health");
 		ctiEnemy.registerArgument("decay_string", "", "the decay of the reinforcement");
 		PlayerSettingAPI.registerSetting(ctiEnemy, commandSection);
+
+		rateLimiter = RateLimiting.createRateLimiter("cti_raytrace" , 6, 6, 1,  2000);
 	}
 
 	public void sendCtiEnemyMessage(Player player, Reinforcement reinforcement) {


### PR DESCRIPTION
Made a few weeks back and forgotten about until today, so may have some unintended jank...

Players can select how far in each direction holograms should extend from the block clicked (a maximum of 2 blocks in each direction from the block clicked). Peripheral holograms will only be visible if a raytrace succeeds. Traces are rate-limited, 1 hologram batch every 2 seconds. 

The current theoretical cap is 3.1 traces per tick. 

No idea how reasonable this number is, it could easily be adjusted 5-10 times lower if desired. 

![holo2](https://user-images.githubusercontent.com/40185801/113902024-75fb5f80-979d-11eb-9a47-2a165b352f28.gif)
