### PR TITLE
Show coordinates of clicked block in chat message as hover text

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	<groupId>vg.civcraft.mc.citadel</groupId>
 	<artifactId>Citadel</artifactId>
 	<packaging>jar</packaging>
-	<version>4.1.1</version>
+	<version>4.2.0</version>
 	<name>Citadel</name>
 	<url>https://github.com/civclassic/Citadel</url>
 

--- a/src/main/java/vg/civcraft/mc/citadel/CitadelUtility.java
+++ b/src/main/java/vg/civcraft/mc/citadel/CitadelUtility.java
@@ -1,7 +1,12 @@
 package vg.civcraft.mc.citadel;
 
 import java.util.logging.Level;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -14,10 +19,9 @@ import vg.civcraft.mc.namelayer.group.Group;
 /**
  * Just a useful class with general and misplaced methods that can be called
  * from anywhere.
- *
  */
 public class CitadelUtility {
-	
+
 	private CitadelUtility() {
 	}
 
@@ -71,8 +75,29 @@ public class CitadelUtility {
 		receiver.sendMessage(color + message);
 		if (Citadel.getInstance().getConfigManager().logMessages()) {
 			Citadel.getInstance().getLogger().log(Level.INFO, "Sent {0} reply {1}",
-					new Object[] { receiver.getName(), message });
+					new Object[]{receiver.getName(), message});
 		}
+	}
+
+	public static void sendAndLog(CommandSender receiver, ChatColor color, String message, Location location) {
+		final TextComponent component = new TextComponent(color + message);
+		addCoordsHoverComponent(component, location);
+		receiver.spigot().sendMessage(component);
+		if (Citadel.getInstance().getConfigManager().logMessages()) {
+			Citadel.getInstance().getLogger().log(Level.INFO, "Sent {0} reply {1}",
+					new Object[]{receiver.getName(), message});
+		}
+	}
+
+	private static BaseComponent addCoordsHoverComponent(BaseComponent component, Location location) {
+		String hoverText = String.format("Location: %s %s %s",
+				location.getBlockX(),
+				location.getBlockY(),
+				location.getBlockZ());
+		component.setHoverEvent(new HoverEvent(
+				HoverEvent.Action.SHOW_TEXT,
+				new Text(hoverText)));
+		return component;
 	}
 
 	public static void debugLog(String msg) {
@@ -96,11 +121,12 @@ public class CitadelUtility {
 	}
 
 	public static boolean attemptReinforcementCreation(Block block, ReinforcementType type, Group group,
-			Player player) {
+	                                                   Player player) {
 		// check if group still exists
 		if (!group.isValid()) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED,
-					"The group " + group.getName() + " seems to have been deleted in the mean time");
+					"The group " + group.getName() + " seems to have been deleted in the mean time",
+					block.getLocation());
 			Citadel.getInstance().getStateManager().setState(player, null);
 			return true;
 		}
@@ -108,7 +134,8 @@ public class CitadelUtility {
 		if (!NameAPI.getGroupManager().hasAccess(group, player.getUniqueId(),
 				CitadelPermissionHandler.getReinforce())) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED,
-					"You seem to have lost permission to reinforce on " + group.getName());
+					"You seem to have lost permission to reinforce on " + group.getName(),
+					block.getLocation());
 			Citadel.getInstance().getStateManager().setState(player, null);
 			return true;
 		}
@@ -121,7 +148,9 @@ public class CitadelUtility {
 		}
 		// check if reinforcement can reinforce that block
 		if (!type.canBeReinforced(block.getType())) {
-			CitadelUtility.sendAndLog(player, ChatColor.RED, type.getName() + " can not reinforce " + block.getType());
+			CitadelUtility.sendAndLog(player, ChatColor.RED,
+					type.getName() + " can not reinforce " + block.getType(),
+					block.getLocation());
 			return true;
 		}
 		ItemMap playerItems = new ItemMap(player.getInventory());
@@ -138,7 +167,9 @@ public class CitadelUtility {
 		}
 		if (available < required) {
 			Citadel.getInstance().getStateManager().setState(player, null);
-			CitadelUtility.sendAndLog(player, ChatColor.RED, "You have no items left to reinforce with " + type.getName());
+			CitadelUtility.sendAndLog(player, ChatColor.RED,
+					"You have no items left to reinforce with " + type.getName(),
+					block.getLocation());
 			return true;
 		}
 		Reinforcement newRein = ReinforcementLogic.callReinforcementCreationEvent(player, block, type, group);

--- a/src/main/java/vg/civcraft/mc/citadel/command/Acid.java
+++ b/src/main/java/vg/civcraft/mc/citadel/command/Acid.java
@@ -58,23 +58,30 @@ public class Acid extends StandaloneCommand {
 			}
 			long neededTime = acidMan.getRemainingAcidMaturationTime(reinforcement);
 			if (neededTime > 0) {
-				CitadelUtility.sendAndLog(p, ChatColor.RED, "That acid block will be mature in "
-						+ TextUtil.formatDuration(neededTime, TimeUnit.MILLISECONDS));
+				CitadelUtility.sendAndLog(p, ChatColor.RED,
+						"That acid block will be mature in "
+								+ TextUtil.formatDuration(neededTime, TimeUnit.MILLISECONDS),
+						block.getLocation());
 				return true;
 			}
 			Block topFace = block.getRelative(BlockFace.UP);
 			if (MaterialUtils.isAir(topFace.getType())) {
-				CitadelUtility.sendAndLog(p, ChatColor.RED, "There is no block above to acid block.");
+				CitadelUtility.sendAndLog(p, ChatColor.RED,
+						"There is no block above to acid block.",
+						block.getLocation());
 				return true;
 			}
 			Reinforcement topRein = ReinforcementLogic.getReinforcementProtecting(topFace);
 			if (topRein == null) {
-				CitadelUtility.sendAndLog(p, ChatColor.RED, "The block above doesn't have a reinforcement.");
+				CitadelUtility.sendAndLog(p, ChatColor.RED,
+						"The block above doesn't have a reinforcement.",
+						block.getLocation());
 				return true;
 			}
 			if (!acidMan.canAcidBlock(reinforcement.getType(), topRein.getType())) {
 				CitadelUtility.sendAndLog(p, ChatColor.RED,
-						reinforcement.getType().getName() + " can not acid away " + topRein.getType().getName());
+						reinforcement.getType().getName() + " can not acid away " + topRein.getType().getName(),
+						block.getLocation());
 				return true;
 			}
 			ReinforcementAcidBlockedEvent event = new ReinforcementAcidBlockedEvent(p, reinforcement, topRein);
@@ -89,7 +96,7 @@ public class Acid extends StandaloneCommand {
 
 			if (Citadel.getInstance().getConfigManager().logHostileBreaks()) {
 				Citadel.getInstance().getLogger().log(Level.INFO, "Acid at {0} broke {1} at {2}, activated by {3}",
-						new Object[] { block.getLocation(), topFace.getType(), topFace.getLocation(), p.getName() });
+						new Object[]{block.getLocation(), topFace.getType(), topFace.getLocation(), p.getName()});
 			}
 			foundAny = true;
 			reinforcement.setHealth(-1);
@@ -111,7 +118,8 @@ public class Acid extends StandaloneCommand {
 
 	/**
 	 * Checks if a containers contents can be dropped
-	 * @param  block  Container being acid blocked
+	 *
+	 * @param block Container being acid blocked
 	 * @return true if contents have been successfully dropped
 	 */
 

--- a/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/BlockListener.java
@@ -69,7 +69,7 @@ public class BlockListener implements Listener {
 		if (block.getRelative(0, 1, 0).getType() == matfire) {
 			block.getRelative(0, 1, 0).setType(Material.AIR);
 		} // Essential
-			// Extended fire protection (recommend)
+		// Extended fire protection (recommend)
 		if (block.getRelative(1, 0, 0).getType() == matfire) {
 			block.getRelative(1, 0, 0).setType(Material.AIR);
 		}
@@ -96,7 +96,6 @@ public class BlockListener implements Listener {
 				event.setCancelled(true);
 			}
 		}
-
 	}
 
 	// Stop comparators from being placed unless the reinforcement is insecure
@@ -112,7 +111,8 @@ public class BlockListener implements Listener {
 		if (ReinforcementLogic.isPreventingBlockAccess(event.getPlayer(), block)) {
 			event.setCancelled(true);
 			CitadelUtility.sendAndLog(event.getPlayer(), ChatColor.RED,
-					"You can not place this because it'd allow bypassing a nearby reinforcement");
+					"You can not place this because it'd allow bypassing a nearby reinforcement",
+					block.getLocation());
 			return;
 		}
 		// Comparators can also read through a single opaque block
@@ -121,7 +121,8 @@ public class BlockListener implements Listener {
 					block.getRelative(comparator.getFacing().getOppositeFace()))) {
 				event.setCancelled(true);
 				CitadelUtility.sendAndLog(event.getPlayer(), ChatColor.RED,
-						"You can not place this because it'd allow bypassing a nearby reinforcement");
+						"You can not place this because it'd allow bypassing a nearby reinforcement",
+						block.getLocation());
 			}
 		}
 	}
@@ -192,7 +193,7 @@ public class BlockListener implements Listener {
 				e.setCancelled(true);
 				String msg = String.format("%s is locked with %s%s", e.getClickedBlock().getType().name(),
 						ChatColor.AQUA, rein.getType().getName());
-				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, msg);
+				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, msg, e.getClickedBlock().getLocation());
 			}
 			return;
 		}
@@ -201,7 +202,7 @@ public class BlockListener implements Listener {
 				e.setCancelled(true);
 				String msg = String.format("%s is locked with %s%s", e.getClickedBlock().getType().name(),
 						ChatColor.AQUA, rein.getType().getName());
-				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, msg);
+				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, msg, e.getClickedBlock().getLocation());
 			}
 		}
 	}
@@ -218,7 +219,7 @@ public class BlockListener implements Listener {
 			if (rel.getType() == mat && ReinforcementLogic.isPreventingBlockAccess(e.getPlayer(), rel)) {
 				e.setCancelled(true);
 				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED,
-						"You can not place this because it'd allow bypassing a nearby reinforcement");
+						"You can not place this because it'd allow bypassing a nearby reinforcement", rel.getLocation());
 				break;
 			}
 		}
@@ -345,7 +346,6 @@ public class BlockListener implements Listener {
 		}
 	}
 
-
 	@EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
 	public void preventHarvestingHoney(PlayerInteractEvent pie) {
 		if (!pie.hasBlock()) {
@@ -402,7 +402,7 @@ public class BlockListener implements Listener {
 			pie.setCancelled(true);
 			String msg = String.format("%s is locked with %s%s", pie.getClickedBlock().getType().name(), ChatColor.AQUA,
 					rein.getType().getName());
-			CitadelUtility.sendAndLog(pie.getPlayer(), ChatColor.RED, msg);
+			CitadelUtility.sendAndLog(pie.getPlayer(), ChatColor.RED, msg, pie.getClickedBlock().getLocation());
 		}
 	}
 
@@ -444,7 +444,6 @@ public class BlockListener implements Listener {
 			return;
 		}
 		event.setCancelled(true);
-		CitadelUtility.sendAndLog(clicker, ChatColor.RED, "You cannot modify that lectern.");
+		CitadelUtility.sendAndLog(clicker, ChatColor.RED, "You cannot modify that lectern.", lecternLocation);
 	}
-
 }

--- a/src/main/java/vg/civcraft/mc/citadel/listener/ModeListener.java
+++ b/src/main/java/vg/civcraft/mc/citadel/listener/ModeListener.java
@@ -124,7 +124,7 @@ public class ModeListener implements Listener {
 	}
 
 	private static void updateDisplaySetting(Player player, DisplayLocationSetting locSetting, boolean state, String text,
-			BottomLine bottomLine, CivScoreBoard scoreBoard) {
+	                                         BottomLine bottomLine, CivScoreBoard scoreBoard) {
 		if (player == null) {
 			return;
 		}
@@ -203,7 +203,7 @@ public class ModeListener implements Listener {
 		boolean showChat = settingMan.shouldShowChatInCti(player.getUniqueId());
 		if (rein == null) {
 			if (showChat) {
-				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.YELLOW, "Not reinforced");
+				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.YELLOW, "Not reinforced", e.getClickedBlock().getLocation());
 			}
 			return;
 		}
@@ -213,7 +213,7 @@ public class ModeListener implements Listener {
 		boolean showHolo = settingMan.shouldShowHologramInCti(player.getUniqueId());
 		if (!rein.hasPermission(player, CitadelPermissionHandler.getInfo())) {
 			if (showChat) {
-				Citadel.getInstance().getSettingManager().sendCtiEnemyMessage(player, rein);
+				Citadel.getInstance().getSettingManager().sendCtiEnemyMessage(player, rein, e.getClickedBlock().getLocation());
 			}
 			if (showHolo) {
 				showHolo(rein, player);
@@ -248,7 +248,7 @@ public class ModeListener implements Listener {
 					sb.append(String.format("%sAcid block mature in %s", ChatColor.YELLOW, TextUtil.formatDuration(remainingTime, TimeUnit.MILLISECONDS)));
 				}
 			}
-			CitadelUtility.sendAndLog(player, ChatColor.GREEN, sb.toString().trim());
+			CitadelUtility.sendAndLog(player, ChatColor.GREEN, sb.toString().trim(), e.getClickedBlock().getLocation());
 		}
 		if (showHolo) {
 			showHolo(rein, player);
@@ -276,5 +276,4 @@ public class ModeListener implements Listener {
 			holoManager.showInfoHolo(rein, player);
 		}
 	}
-
 }

--- a/src/main/java/vg/civcraft/mc/citadel/model/CitadelSettingManager.java
+++ b/src/main/java/vg/civcraft/mc/citadel/model/CitadelSettingManager.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.UUID;
 import org.bukkit.ChatColor;
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -54,15 +55,15 @@ public class CitadelSettingManager {
 	public DisplayLocationSetting getBypassLocationSetting() {
 		return ctbLocationSetting;
 	}
-	
+
 	public DisplayLocationSetting getModeLocationSetting() {
 		return modeLocationSetting;
 	}
-	
+
 	public DisplayLocationSetting getInformationLocationSetting() {
 		return ctiLocationSetting;
 	}
-	
+
 	public BooleanSetting getBypass() {
 		return byPass;
 	}
@@ -78,11 +79,11 @@ public class CitadelSettingManager {
 	public boolean shouldShowChatInCti(UUID uuid) {
 		return showChatMsgInCti.getValue(uuid);
 	}
-	
+
 	public boolean shouldCtoDisableCti(UUID uuid) {
 		return ctoDisableCti.getValue(uuid);
 	}
-	
+
 	public boolean shouldCtoDisableCtb(UUID uuid) {
 		return ctoDisableCtb.getValue(uuid);
 	}
@@ -109,7 +110,7 @@ public class CitadelSettingManager {
 		informationMode = new BooleanSetting(Citadel.getInstance(), false, "Information mode", "citadelInformationMode",
 				"Displays information about reinforced blocks when interacting with them");
 		PlayerSettingAPI.registerSetting(informationMode, menu);
-		
+
 		easyMode = new BooleanSetting(Citadel.getInstance(), false, "Easy reinforcing mode", "citadelEasyMode",
 				"Allows automatically reinforcing to your default group with reinforcement materials from your off hand");
 		PlayerSettingAPI.registerSetting(easyMode, menu);
@@ -127,27 +128,27 @@ public class CitadelSettingManager {
 				"How long should holograms in information mode remain visible, measured in milli seconds", false, 1000,
 				30000);
 		PlayerSettingAPI.registerSetting(hologramDuration, menu);
-		
+
 		ctbLocationSetting = new DisplayLocationSetting(Citadel.getInstance(), DisplayLocation.NONE, "Bypass display location"
 				, "citadelBypassDisplayLocation", new ItemStack(Material.GOLDEN_PICKAXE), "bypass");
 		PlayerSettingAPI.registerSetting(ctbLocationSetting, menu);
-		
+
 		ctiLocationSetting = new DisplayLocationSetting(Citadel.getInstance(), DisplayLocation.SIDEBAR, "Information mode display location"
 				, "citadelInfoModeDisplayLocation", new ItemStack(Material.BOOKSHELF), "reinforcement info mode");
 		PlayerSettingAPI.registerSetting(ctiLocationSetting, menu);
-		
+
 		modeLocationSetting = new DisplayLocationSetting(Citadel.getInstance(), DisplayLocation.SIDEBAR, "Citadel mode display location"
 				, "citadelReinModeDisplayLocation", new ItemStack(Material.NETHER_STAR), "Citadel mode");
 		PlayerSettingAPI.registerSetting(modeLocationSetting, menu);
-		
-		ctoDisableCtb =  new BooleanSetting(Citadel.getInstance(), false, "/cto disable /ctb",
+
+		ctoDisableCtb = new BooleanSetting(Citadel.getInstance(), false, "/cto disable /ctb",
 				"citadelCtoDisableCtb", "Should /cto disable Bypass mode (/ctb)");
 		PlayerSettingAPI.registerSetting(ctoDisableCtb, menu);
-		
-		ctoDisableCti =  new BooleanSetting(Citadel.getInstance(), true, "/cto disable /cti",
+
+		ctoDisableCti = new BooleanSetting(Citadel.getInstance(), true, "/cto disable /cti",
 				"citadelCtoDisableCti", "Should /cto disable Information mode (/cti)");
-		PlayerSettingAPI.registerSetting(ctoDisableCti, menu);		
-		
+		PlayerSettingAPI.registerSetting(ctoDisableCti, menu);
+
 		MenuSection commandSection = menu.createMenuSection("Command replies",
 				"Allows configuring the replies received when interacting with reinforcements or Citadel commands. For advanced users only");
 
@@ -193,7 +194,7 @@ public class CitadelSettingManager {
 		PlayerSettingAPI.registerSetting(ctiEnemy, commandSection);
 	}
 
-	public void sendCtiEnemyMessage(Player player, Reinforcement reinforcement) {
+	public void sendCtiEnemyMessage(Player player, Reinforcement reinforcement, Location location) {
 		Map<String, String> args = new TreeMap<>();
 		ReinforcementType type = reinforcement.getType();
 		String percFormat = ctiPercentageHealth.getValue(player)
@@ -210,8 +211,8 @@ public class CitadelSettingManager {
 			String ctiDecayFormat = ctiDecay.getValue(player).replaceAll("%%decay%%", ctiDecayAmountFormat);
 			args.put("decay_string", ctiDecayFormat);
 		} else {
-			args.put("decay_string","");
+			args.put("decay_string", "");
 		}
-		CitadelUtility.sendAndLog(player, ChatColor.RESET, ctiEnemy.formatReply(player.getUniqueId(), args));
+		CitadelUtility.sendAndLog(player, ChatColor.RESET, ctiEnemy.formatReply(player.getUniqueId(), args), location);
 	}
 }

--- a/src/main/java/vg/civcraft/mc/citadel/playerstate/AbstractPlayerState.java
+++ b/src/main/java/vg/civcraft/mc/citadel/playerstate/AbstractPlayerState.java
@@ -69,7 +69,8 @@ public abstract class AbstractPlayerState {
 		}
 		if (hasAccess) {
 			CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.GREEN,
-					"You could bypass this reinforcement " + "if you turn bypass mode on with '/ctb'");
+					"You could bypass this reinforcement if you turn bypass mode on with '/ctb'",
+					e.getBlock().getLocation());
 		}
 		e.setCancelled(true);
 		float damage = ReinforcementLogic.getDamageApplied(rein);
@@ -105,5 +106,4 @@ public abstract class AbstractPlayerState {
 
 	@Override
 	public abstract boolean equals(Object o);
-
 }

--- a/src/main/java/vg/civcraft/mc/citadel/playerstate/InsecureState.java
+++ b/src/main/java/vg/civcraft/mc/citadel/playerstate/InsecureState.java
@@ -35,13 +35,17 @@ public class InsecureState extends AbstractPlayerState {
 			rein.toggleInsecure();
 			if (rein.isInsecure()) {
 				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.YELLOW,
-						e.getClickedBlock().getType().name() + " is now insecure");
+						e.getClickedBlock().getType().name() + " is now insecure",
+						e.getClickedBlock().getLocation());
 			} else {
 				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.GREEN,
-						e.getClickedBlock().getType().name() + " is now secure");
+						e.getClickedBlock().getType().name() + " is now secure",
+						e.getClickedBlock().getLocation());
 			}
 		} else {
-			CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, "You are not allowed to make this reinforcement insecure");
+			CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED,
+					"You are not allowed to make this reinforcement insecure",
+					e.getClickedBlock().getLocation());
 		}
 	}
 
@@ -54,5 +58,4 @@ public class InsecureState extends AbstractPlayerState {
 	public String getOverlayText() {
 		return ChatColor.GREEN + "CTIN";
 	}
-
 }

--- a/src/main/java/vg/civcraft/mc/citadel/playerstate/PatchState.java
+++ b/src/main/java/vg/civcraft/mc/citadel/playerstate/PatchState.java
@@ -35,30 +35,37 @@ public class PatchState extends AbstractPlayerState {
 		Reinforcement rein = ReinforcementLogic.getReinforcementProtecting(e.getClickedBlock());
 		Player player = e.getPlayer();
 		if (rein == null) {
-			CitadelUtility.sendAndLog(player, ChatColor.RED, "This block is not reinforced");
+			CitadelUtility.sendAndLog(player, ChatColor.RED,
+					"This block is not reinforced",
+					e.getClickedBlock().getLocation());
 			return;
 		}
 		if (!rein.hasPermission(player, CitadelPermissionHandler.getRepair())) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED,
-					"You do not have permission to repair reinforcements on this group");
+					"You do not have permission to repair reinforcements on this group",
+					e.getClickedBlock().getLocation());
 			return;
 		}
 		if (rein.getHealth() >= rein.getType().getHealth()) {
 			if (rein.hasPermission(player, CitadelPermissionHandler.getRepair())) {
 				CitadelUtility.sendAndLog(player, ChatColor.GOLD,
 						"Reinforcement is already at " + ModeListener.formatHealth(rein) + ChatColor.GOLD
-								+ " health with " + ChatColor.AQUA + rein.getType().getName() + ChatColor.GOLD + " on "
-								+ ChatColor.LIGHT_PURPLE + rein.getGroup().getName());
+								+ " health with " + ChatColor.AQUA + rein.getType().getName() + ChatColor.GOLD
+								+ " on " + ChatColor.LIGHT_PURPLE + rein.getGroup().getName(),
+						e.getClickedBlock().getLocation());
 			} else {
-				CitadelUtility.sendAndLog(player, ChatColor.GOLD, "Reinforcement is already at "
-						+ ModeListener.formatHealth(rein) + ChatColor.GOLD + " health");
+				CitadelUtility.sendAndLog(player, ChatColor.GOLD,
+						"Reinforcement is already at " + ModeListener.formatHealth(rein) + ChatColor.GOLD + " health",
+						e.getClickedBlock().getLocation());
 			}
 			return;
 		}
 		ItemMap playerMap = new ItemMap(player.getInventory());
 		if (playerMap.getAmount(rein.getType().getItem()) <= 0) {
-			CitadelUtility.sendAndLog(player, ChatColor.RED, "You don't have the item required to repair " + ChatColor.AQUA
-					+ rein.getType().getName() + ChatColor.GOLD + " reinforcements");
+			CitadelUtility.sendAndLog(player, ChatColor.RED,
+					"You don't have the item required to repair " + ChatColor.AQUA
+							+ rein.getType().getName() + ChatColor.GOLD + " reinforcements",
+					e.getClickedBlock().getLocation());
 			return;
 		}
 		ReinforcementRepairEvent repairEvent = new ReinforcementRepairEvent(e.getPlayer(), rein);
@@ -84,5 +91,4 @@ public class PatchState extends AbstractPlayerState {
 	public String getOverlayText() {
 		return ChatColor.GREEN + "CTP";
 	}
-
 }

--- a/src/main/java/vg/civcraft/mc/citadel/playerstate/ReinforcingState.java
+++ b/src/main/java/vg/civcraft/mc/citadel/playerstate/ReinforcingState.java
@@ -54,27 +54,31 @@ public class ReinforcingState extends AbstractPlayerState {
 		Player player = e.getPlayer();
 		// does the player have an item?
 		if (e.getItem() == null) {
-			CitadelUtility.sendAndLog(player, ChatColor.RED, "You have nothing in your hand to reinforce with");
+			CitadelUtility.sendAndLog(player, ChatColor.RED, "You have nothing in your hand to reinforce with",
+					e.getClickedBlock().getLocation());
 			return;
 		}
 		ReinforcementType type = Citadel.getInstance().getReinforcementTypeManager().getByItemStack(e.getItem());
 		// is it a valid item to reinforce with
 		if (type == null) {
-			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with this item");
+			CitadelUtility.sendAndLog(player, ChatColor.RED, "You can not reinforce with this item",
+					e.getClickedBlock().getLocation());
 			return;
 		}
 		Block block = ReinforcementLogic.getResponsibleBlock(e.getClickedBlock());
 		// can the item reinforce the clicked block
 		if (!type.canBeReinforced(block.getType())) {
 			CitadelUtility.sendAndLog(player, ChatColor.RED,
-					type.getName() + " can not reinforce " + block.getType());
+					type.getName() + " can not reinforce " + block.getType(),
+					block.getLocation());
 			return;
 		}
 		// does the player have permission to reinforce on that group
 		if (!NameAPI.getGroupManager().hasAccess(group, e.getPlayer().getUniqueId(),
 				CitadelPermissionHandler.getReinforce())) {
 			CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED,
-					"You seem to have lost permission to reinforce on " + group.getName());
+					"You seem to have lost permission to reinforce on " + group.getName(),
+					e.getClickedBlock().getLocation());
 			Citadel.getInstance().getStateManager().setState(e.getPlayer(), null);
 			return;
 		}
@@ -83,7 +87,8 @@ public class ReinforcingState extends AbstractPlayerState {
 		if (rein != null) {
 			if (!rein.hasPermission(e.getPlayer(), CitadelPermissionHandler.getBypass())) {
 				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED,
-						"You do not have permission to bypass reinforcements on " + group.getName());
+						"You do not have permission to bypass reinforcements on " + group.getName(),
+						e.getClickedBlock().getLocation());
 				return;
 			}
 		}
@@ -92,7 +97,8 @@ public class ReinforcingState extends AbstractPlayerState {
 			// check inventory for reinforcement item
 			ItemMap toConsume = new ItemMap(type.getItem());
 			if (!toConsume.isContainedIn(player.getInventory())) {
-				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, "No reinforcing item found in your inventory?");
+				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED, "No reinforcing item found in your inventory?",
+						e.getClickedBlock().getLocation());
 				return;
 			}
 			if (rein == null) {
@@ -105,7 +111,8 @@ public class ReinforcingState extends AbstractPlayerState {
 			// consume item from inventory
 			if (!toConsume.removeSafelyFrom(player.getInventory())) {
 				CitadelUtility.sendAndLog(e.getPlayer(), ChatColor.RED,
-						"Failed to remove reinforcement item from your inventory");
+						"Failed to remove reinforcement item from your inventory",
+						e.getClickedBlock().getLocation());
 				return;
 			}
 		}
@@ -144,14 +151,17 @@ public class ReinforcingState extends AbstractPlayerState {
 					rein.setHealth(type.getHealth());
 					rein.resetCreationTime();
 					CitadelUtility.sendAndLog(player, ChatColor.GREEN,
-							"Updated reinforcement to " + rein.getType().getName() + " on " + group.getName());
+							"Updated reinforcement to " + rein.getType().getName() + " on " + group.getName(),
+							e.getClickedBlock().getLocation());
 				} else if (changedGroup) {
 					CitadelUtility.sendAndLog(player, ChatColor.GREEN,
-							"Updated group to " + ChatColor.LIGHT_PURPLE + group.getName());
+							"Updated group to " + ChatColor.LIGHT_PURPLE + group.getName(),
+							e.getClickedBlock().getLocation());
 				}
 			} else if (changedGroup) {
 				CitadelUtility.sendAndLog(player, ChatColor.GREEN,
-						"Updated group to " + ChatColor.LIGHT_PURPLE + group.getName());
+						"Updated group to " + ChatColor.LIGHT_PURPLE + group.getName(),
+						e.getClickedBlock().getLocation());
 			}
 		}
 	}


### PR DESCRIPTION
Similar to 1.12 and before.

Maxopoly called its removal an ["accidental casualty"](https://github.com/CivClassic/Citadel/commit/327b672319f245422996eb983af3dc4a3aa21481#commitcomment-55958088).

This is useful for associating the reinforcement status with a block location, for example to allow a [mod](https://github.com/caucow/RandomCodeAndProjects/blob/main/CmdReinforcement.java) to display the reinforcement type, group name, and other such information directly on the block faces instead of using holograms which aren't very configurable and tend to get in the way when checking a lot of reinforcements in a large structure.

[![2021-10-21-235644_566x69_scrot](https://user-images.githubusercontent.com/2612164/138362509-f6a665c8-1950-4355-b88a-f54f3254e785.png)